### PR TITLE
Using debian:jessie instead of Ubuntu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM debian:jessie
 MAINTAINER Larry Howard <larry.howard@vanderbilt.edu>
 
+ENV DEBIAN_FRONTEND noninteractive
+
 # install Ruby
 RUN apt-get update && apt-get install -yqq ruby rubygems-integration
 
@@ -9,5 +11,5 @@ RUN gem install fakes3 -v 0.1.5.2
 
 # run fake-s3
 RUN mkdir -p /fakes3_root
-CMD ["/usr/local/bin/fakes3", "-r",  "/fakes3_root", "-p",  "4569"]
+CMD ["/usr/local/bin/fakes3", "-r",  "/fakes3_root", "-p",  "4569", "-h", "0.0.0.0"]
 EXPOSE 4569


### PR DESCRIPTION
[Debian is a smaller image](http://blog.javabien.net/2014/06/18/size-of-docker-images-which-linux-is-smaller/) and it works with it.

I've also added `0.0.0.0` as the hostname, since docker containers have their own hostname and IP, and I don't think anyone would like to mess with his `/etc/hosts` file every time he launches a new `fake-s3` instance.

and also, it may be the best to add `-p 4569:4569` to the `README.md` file
