### PR TITLE
Update to latest fake-s3 version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,10 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -yqq ruby rubygems-integration
 
 # install fake-s3
-RUN gem install fakes3 -v 0.1.5.2
+RUN gem install fakes3 -v 0.2.1
 
 # run fake-s3
 RUN mkdir -p /fakes3_root
 ENTRYPOINT ["/usr/local/bin/fakes3"]
-CMD ["-r",  "/fakes3_root", "-p",  "4569", "-h", "0.0.0.0"]
+CMD ["-r",  "/fakes3_root", "-p",  "4569"]
 EXPOSE 4569


### PR DESCRIPTION
Removed the host parameter that causes conflicts with the newer version.